### PR TITLE
Parallelize LLM predictions for full Amazon catalogue PCF

### DIFF
--- a/scripts/predict_carbon.py
+++ b/scripts/predict_carbon.py
@@ -95,7 +95,8 @@ def parse_args() -> argparse.Namespace:
         "--llm-amazon-limit",
         type=int,
         default=0,
-        help="Optional number of Amazon rows to score with the LLM baselines.",
+        help="Number of Amazon rows to score with the LLM baselines. "
+        "Default 0 skips LLM. Use -1 for all rows.",
     )
     parser.add_argument(
         "--llm-model",
@@ -133,6 +134,13 @@ def parse_args() -> argparse.Namespace:
         "--non-deterministic",
         action="store_true",
         help="Disable deterministic retrieval settings.",
+    )
+    parser.add_argument(
+        "--llm-workers",
+        type=int,
+        default=1,
+        help="Number of concurrent LLM prediction workers (default: 1). "
+        "Increase for API-based or vLLM-backed models.",
     )
     parser.add_argument(
         "--llm-cache-only",
@@ -254,6 +262,7 @@ def _build_estimator(
         random_seed=args.seed,
         deterministic=deterministic,
         num_threads=args.num_threads,
+        llm_workers=args.llm_workers,
     )
     return PCFRetrievalEstimator(config)
 
@@ -288,7 +297,8 @@ def _build_run_metadata(
         "evaluation_rows": int(len(eval_predictions)),
         "llm_enabled": llm_client is not None,
         "llm_model": args.llm_model if llm_client is not None else None,
-        "llm_amazon_limit": args.llm_amazon_limit,
+        "llm_amazon_limit": None if args.llm_amazon_limit < 0 else args.llm_amazon_limit,
+        "llm_workers": args.llm_workers,
         "llm_cache_only": args.llm_cache_only,
         "amazon_output": str(amazon_output),
         "evaluation_output": str(eval_output),
@@ -335,12 +345,13 @@ def main() -> None:
 
     amazon_meta = _load_amazon_metadata(args.amazon_limit)
 
+    llm_amazon_limit = None if args.llm_amazon_limit < 0 else args.llm_amazon_limit
     amazon_predictions = estimator.predict_amazon_products(
         amazon_meta,
         llm_client=llm_client,
         llm_model_name=args.llm_model,
         llm_cache_path=llm_cache_path,
-        llm_limit=args.llm_amazon_limit,
+        llm_limit=llm_amazon_limit,
         llm_cache_only=args.llm_cache_only,
     )
 

--- a/src/carbon/retrieval.py
+++ b/src/carbon/retrieval.py
@@ -16,6 +16,8 @@ import logging
 import os
 import random
 import re
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Sequence
@@ -99,6 +101,7 @@ class RetrievalConfig:
     random_seed: int = 42
     deterministic: bool = True
     num_threads: int = 1
+    llm_workers: int = 1
 
 
 def set_global_determinism(
@@ -147,6 +150,7 @@ class JsonlPredictionCache:
     def __init__(self, path: Path | None) -> None:
         self._path = Path(path) if path is not None else None
         self._records: dict[str, float] = {}
+        self._lock = threading.Lock()
 
         if self._path is not None and self._path.exists():
             with self._path.open("r", encoding="utf-8") as handle:
@@ -160,20 +164,22 @@ class JsonlPredictionCache:
                     self._records[key] = value
 
     def get(self, key: str) -> float | None:
-        return self._records.get(key)
+        with self._lock:
+            return self._records.get(key)
 
     def set(self, key: str, value: float, **metadata: Any) -> None:
-        if key in self._records:
-            return
+        with self._lock:
+            if key in self._records:
+                return
 
-        self._records[key] = value
-        if self._path is None:
-            return
+            self._records[key] = value
+            if self._path is None:
+                return
 
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        record = {"key": key, "value": float(value), **metadata}
-        with self._path.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(record) + "\n")
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            record = {"key": key, "value": float(value), **metadata}
+            with self._path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(record) + "\n")
 
 
 class SentenceTransformerEncoder:
@@ -967,13 +973,14 @@ class PCFRetrievalEstimator:
             if llm_client is not None
             else (llm_model_name or DEFAULT_LLM_MODEL)
         )
-        log.info("Running %s LLM predictions for %d items", method_name, run_limit)
+        log.info(
+            "Running %s LLM predictions for %d items (workers=%d)",
+            method_name,
+            run_limit,
+            self.config.llm_workers,
+        )
 
-        for row_idx in tqdm(
-            range(run_limit),
-            desc=f"LLM {method_name}",
-            unit="prompt",
-        ):
+        def _predict_one(row_idx: int) -> tuple[int, float | None]:
             row = df.iloc[row_idx]
             prompt = _build_llm_prompt(
                 row,
@@ -981,17 +988,14 @@ class PCFRetrievalEstimator:
                 title_col=title_col,
                 top_k=self.config.top_k,
             )
-
             cache_key = hashlib.sha256(
                 f"{model_name}\n{method_name}\n{prompt}".encode("utf-8")
             ).hexdigest()
             cached = cache.get(cache_key)
             if cached is not None:
-                predictions[row_idx] = cached
-                continue
+                return row_idx, cached
             if cache_only:
-                continue
-
+                return row_idx, None
             try:
                 if llm_client is None:
                     raise RuntimeError("Live LLM prediction requested without an LLM client.")
@@ -1003,15 +1007,18 @@ class PCFRetrievalEstimator:
                     row_idx,
                     exc,
                 )
-                continue
+                return row_idx, None
+            cache.set(cache_key, value, method=method_name, model=model_name)
+            return row_idx, value
 
-            predictions[row_idx] = value
-            cache.set(
-                cache_key,
-                value,
-                method=method_name,
-                model=model_name,
-            )
+        with ThreadPoolExecutor(max_workers=self.config.llm_workers) as executor:
+            futures = {executor.submit(_predict_one, i): i for i in range(run_limit)}
+            with tqdm(total=run_limit, desc=f"LLM {method_name}", unit="prompt") as pbar:
+                for future in as_completed(futures):
+                    row_idx, value = future.result()
+                    if value is not None:
+                        predictions[row_idx] = value
+                    pbar.update(1)
 
         return predictions
 


### PR DESCRIPTION
## Summary

- Replace serial LLM prediction loop with `ThreadPoolExecutor` in `_run_llm_predictions`, controlled by a new `llm_workers` config field (default 1, fully backward-compatible)
- Make `JsonlPredictionCache` thread-safe with a `threading.Lock`
- Add `--llm-workers` CLI arg to `predict_carbon.py`
- Add `-1` support to `--llm-amazon-limit` to score all Amazon rows (mirrors existing `--evaluation-limit -1` behaviour)

## Motivation

Running few-shot LLM predictions on the full Amazon catalogue was infeasible with a serial loop. With a local vLLM server on Colab A100, concurrent requests keep the GPU request queue saturated (vLLM batches them internally), giving a large throughput improvement.

## Usage (Colab A100)

```bash
OPENAI_BASE_URL=http://localhost:8000/v1 \
OPENAI_API_KEY=dummy \
OPENAI_MODEL=Qwen/Qwen2.5-3B-Instruct \
python scripts/predict_carbon.py \
  --llm-workers 32 \
  --llm-amazon-limit -1 \
  --evaluation-limit 0 \
  --amazon-output data/processed/carbon/amazon_pcf_predictions.csv \
  --device cuda
```

## Test plan

- [ ] Smoke test with `--llm-amazon-limit 100 --llm-workers 4` confirms concurrent predictions and cache writes are correct
- [ ] `--llm-amazon-limit -1` scores all rows (no truncation)
- [ ] Serial behaviour unchanged with default `--llm-workers 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)